### PR TITLE
Add the O(1) labs protocol reliability engineer job for new demand

### DIFF
--- a/sfbay/O(1) Labs -- Protocol Reliability Engineer (Pays $20,000 Bounty).md
+++ b/sfbay/O(1) Labs -- Protocol Reliability Engineer (Pays $20,000 Bounty).md
@@ -1,5 +1,5 @@
 O(1) Labs is seeking a protocol reliability engineer who wants to use modern tools like Terraform, Kubernetes, and Docker to develop the core tooling we use to test, monitor, secure, and stabilize our growing cryptocurrency network.
 ------
 - keywords: ["protocol", "engineer", "protocol", "blockchain", "ocaml", "reliability", "Kubernetes", "Terraform", "docker"]
-- url:
+- url: https://jobs.rezscore.com/token/gSjv-g8uQE5QgmhTisNA
 - bounty: 20000

--- a/sfbay/O(1) Labs -- Protocol Reliability Engineer (Pays $20,000 Bounty).md
+++ b/sfbay/O(1) Labs -- Protocol Reliability Engineer (Pays $20,000 Bounty).md
@@ -1,0 +1,5 @@
+O(1) Labs is seeking a protocol reliability engineer who wants to use modern tools like Terraform, Kubernetes, and Docker to develop the core tooling we use to test, monitor, secure, and stabilize our growing cryptocurrency network.
+------
+- keywords: ["protocol", "engineer", "protocol", "blockchain", "ocaml", "reliability", "Kubernetes", "Terraform", "docker"]
+- url:
+- bounty: 20000


### PR DESCRIPTION
A new $20,000 Bounty has been added for the O(1) labs protocol reliability engineer position. @zcor will you please add the appropriate URL?